### PR TITLE
Fix for using prettyPhoto for youtube on https

### DIFF
--- a/js/jquery.prettyPhoto.js
+++ b/js/jquery.prettyPhoto.js
@@ -279,7 +279,7 @@
 								movie_id = movie_id.substr(0,movie_id.indexOf('&')); // Strip anything after the &
 						}
 
-						movie = 'http://www.youtube.com/embed/'+movie_id;
+						movie = 'https://www.youtube.com/embed/'+movie_id;
 						(getParam('rel',pp_images[set_position])) ? movie+="?rel="+getParam('rel',pp_images[set_position]) : movie+="?rel=1";
 							
 						if(settings.autoplay) movie += "&autoplay=1";


### PR DESCRIPTION
prettyPhoto uses http-based iframe address, which won't load on secured pages. Using https will make it always work with no side-effects (and actually can speed up iframe loading time).